### PR TITLE
plugin-review

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -5,6 +5,10 @@
  * @package vk-simple-copy-block
  */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 add_action(
 	'init',
 	function () {

--- a/vk-simple-copy-block.php
+++ b/vk-simple-copy-block.php
@@ -3,8 +3,8 @@
  * Plugin Name: VK Simple Copy Block
  * Plugin URI: https://github.com/vektor-inc/vk-simple-copy-block
  * Description: A block to copy the code of the block inside the copy target.
- * Version: 0.0.1
- * Stable tag: 0.0.1
+ * Version: 0.1.0
+ * Stable tag: 0.1.0
  * Requires at least: 6.1
  * Author: Vektor,Inc.
  * Author URI: https://vektor-inc.co.jp


### PR DESCRIPTION
# From WordPress Plugin Review Team 

## Incorrect Stable Tag

In your readme, your 'Stable Tag' does not match the Plugin Version as indicated in your main plugin file.

vk-simple-copy-block/readme.txt:7:Stable tag: 0.1.0
vk-simple-copy-block/vk-simple-copy-block.php:6: * Version: 0.0.1

Your Stable Tag is meant to be the stable version of your plugin, not of WordPress. For your plugin to be properly downloaded from WordPress.org, those values need to be the same. If they're out of sync, your users won't get the right version of your code.

We recommend you use Semantic Versioning (aka SemVer) for managing versions:

https://en.wikipedia.org/wiki/Software_versioning
https://semver.org/

Please note: While currently using the stable tag of trunk currently works in the Plugin Directory, it's not actually a supported or recommended method to indicate new versions and has been known to cause issues with automatic updates.

We ask you please properly use tags and increment them when you release new versions of your plugin, just like you update the plugin version in the main file. Having them match is the best way to be fully forward supporting.

## Allowing Direct File Access to plugin files

Direct file access is when someone directly queries your file. This can be done by simply entering the complete path to the file in the URL bar of the browser but can also be done by doing a POST request directly to the file. For files that only contain a PHP class the risk of something funky happening when directly accessed is pretty small. For files that contain procedural code, functions and function calls, the chance of security risks is a lot bigger.

You can avoid this by putting this code at the top of all php files:

if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly

Example(s) from your plugin:
vk-simple-copy-block/inc/blocks.php:8
vk-simple-copy-block/build/simple-copy/view.asset.php:1 