### PR TITLE
インナーブロックを持つブロックはブロックが壊れるためHTML編集を無効化

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification Change ] Disable HTML editing for blocks with inner blocks, as the blocks are broken.
+
 = 0.1.2 =
 [ Fix ] Translation
 

--- a/src/copy-button-wrap/block.json
+++ b/src/copy-button-wrap/block.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"supports": {
+		"html": false,
 		"className": true,
 		"spacing": {
 			"margin": ["top", "bottom"]

--- a/src/copy-target/block.json
+++ b/src/copy-target/block.json
@@ -9,6 +9,7 @@
 		"vk-simple-copy-block/simple-copy"
 	],
 	"supports": {
+		"html": false,
 		"className": true,
 		"spacing": {
 			"padding": true,

--- a/src/simple-copy/block.json
+++ b/src/simple-copy/block.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"supports": {
+		"html": false,
 		"align": [
 			"wide",
 			"full"


### PR DESCRIPTION
以下と同様の変更です
https://github.com/vektor-inc/vk-blocks-pro/issues/1754
https://github.com/vektor-inc/vk-blocks-pro/pull/1755

simple-copy
copy-target
copy-button-wrap
の３つのブロックでHTML編集が出来ないことを確認お願いします