### PR TITLE
【確認待ち】WordPress6.3テスト追加

### DIFF
--- a/.github/workflows/php_unit_test.yml
+++ b/.github/workflows/php_unit_test.yml
@@ -13,7 +13,7 @@ jobs:
         strategy:
             matrix:
                 php-versions: ['7.4', '8.0', '8.1']
-                wp-versions: ['6.2','6.1.1']
+                wp-versions: ['6.3','6.2','6.1.1']
         name: PHP Unit test ${{ matrix.php-versions }} / WP ${{ matrix.wp-versions }} Test on ${{ matrix.operating-system }}
         services:
             mysql:

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: vektor-inc,shimotomoki
 Donate link:
 Tags: Gutenberg,copy & paste,copy & paste patterns
 Requires at least: 6.1
-Tested up to: 6.2.0
+Tested up to: 6.3
 Stable tag: 0.1.2.0
 Requires PHP: 7.2
 License: GPLv2 or later
@@ -32,6 +32,7 @@ e.g.
 
 == Changelog ==
 
+[ Other ] Update the required WordPress version
 [ Specification Change ] Disable HTML editing for blocks with inner blocks, as the blocks are broken.
 
 = 0.1.2 =


### PR DESCRIPTION
以下と同様の変更です
https://github.com/vektor-inc/vk-blocks-pro/pull/1786
https://github.com/vektor-inc/vk-blocks-pro/issues/1717

Github Actions上で6.3のテストが追加されていることを確認お願いします