### PR TITLE
エディターツールバーにズームアウトのトグルが常に表示されない不具合を修正

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ e.g.
 
 == Changelog ==
 
+[ Specification change ] Fixed the zoom-out toggle not always displaying in the editor toolbar (updated blocks.json API version from 2 to 3).
+
 = 0.1.5 =
 [ Other ] change version only ( change WordPress.org banner ).
 

--- a/src/copy-button-wrap/block.json
+++ b/src/copy-button-wrap/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "vk-simple-copy-block/copy-button-wrap",
 	"category": "vk-simple-copy-block",
 	"title": "Copy Button",

--- a/src/copy-button/block.json
+++ b/src/copy-button/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "vk-simple-copy-block/copy-button",
 	"category": "vk-simple-copy-block",
 	"title": "Copy Button",

--- a/src/copy-target/block.json
+++ b/src/copy-target/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "vk-simple-copy-block/copy-target",
 	"category": "vk-simple-copy-block",
 	"title": "Copy Target",

--- a/src/simple-copy/block.json
+++ b/src/simple-copy/block.json
@@ -1,5 +1,5 @@
 {
-	"apiVersion": 2,
+	"apiVersion": 3,
 	"name": "vk-simple-copy-block/simple-copy",
 	"category": "vk-simple-copy-block",
 	"title": "Simple Copy",


### PR DESCRIPTION
## チケットへのリンク / 変更の理由（元のissueがあればリンクを貼り付ければOK）

https://github.com/vektor-inc/vk-blocks-pro/issues/2289#issuecomment-2446050765

## どういう変更をしたか？
blocks.json の apiVersion を 3 に変更することで、ズームアウトのトグルがエディターツールバーに常に表示されるよう修正しました。

### 変更前 Before
![スクリーンショット 2025-01-27 11 00 42](https://github.com/user-attachments/assets/6521107c-2c70-4020-8b46-6b60a1c8c3e3)

### 変更後 After
![image](https://github.com/user-attachments/assets/3ba32688-e2c0-4497-999e-48c5af0cb83c)

#### ソースコードについて

- [x] 複数の意図の変更 （ 機能の不具合修正 + 別の機能追加など ） を含んでいないか？
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 はそれだけで内容が想像できるものになっているか？紛らわしい命名になっていないか？ → スキップ
- [ ] 関数名 / 変数名 / クラス名 / 保存値名 は既存のコードの命名規則に沿ったものになっているか？ → スキップ

#### デザイン・UI

- [ ] 初見のユーザーが予備知識無しで使っても使いやすいようになっているか？ → スキップ
- [ ] 情報意味を考慮した意味グルーピング・余白になっているか？ → スキップ
- [ ] アラートの表示など追加した場合は他の同様の表示と同じデザインになっているか？ → スキップ

#### プログラムの変更の場合

テストを書かないのは普通ではありません。書けるテストは極力書くようにしてください。
書いていない場合は書かない理由を記載してください。

- [ ] 書けそうなテストは書いたか？→ スキップ
- [ ] 表示要素が仕様通りに表示されない不具合の修正ではない or 表示要素に関する不具合修正の場合テストは書いたか？ → スキップ

#### その他

- [x] readme.txt に変更内容は書いたか？
- [x] Files changed (変更ファイル)の内容は目視でちゃんと確認したか？
- [x] このチェック項目を機械的にチェックするのではなく本当にちゃんと確認をしたか？
- [x] レビュワーが確認しないでリリースしてしまっても問題ないレベルまでちゃんと作りこみ・確認をしたか？

## 変更内容について何を確認したか、どういう方法で確認をしたかなど

1. プラグインで「VK Simple Copy Block」 だけを有効にする。
2. 新規固定ページで「Simple Copy」のブロックを追加する。
3. エディターツールバーにズームアウトのトグルや「ドラッグしてサイズ変更」が常に表示されており、さらに機能していることを確認。
4. 保存し、フロントエンドでブロックが表示、機能していることを確認。

## 確認URL

（　どこかのデモサイトかテストサーバーにデプロイ済みなどで確認できる場合はそのURL　）

## レビュワーの確認方法・確認する内容など

実装者と同じ確認を行ってください。
その他気になる点があれば適宜ご確認ください。

## レビュワーに回す前の確認事項

- [ ] このテンプレートのチェック項目をちゃんと確認してチェックしたか？

---

## レビュワー向け

### 確認して変更が反映されていない場合の確認事項

* プルしたか？
* ビルドしたか？
* ビルドしたディレクトリは正しいか（別の開発環境のディレクトリを見ていないか）？
* npm install したか？
* composer install したか？
