### PR TITLE
[ その他 ] readme.txt に Stable tag を追加

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,6 +5,7 @@ Tags: Gutenberg,copy & paste,copy & paste patterns,block
 Requires at least: 6.7
 Tested up to: 6.7
 Requires PHP: 7.2
+Stable tag: 0.1.7
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 


### PR DESCRIPTION
## Summary
- readme.txt に `Stable tag: 0.1.7` を追加
- `Stable tag` が欠落していると WordPress.org のビルドシステムが zip を正しく再生成せず、古いバージョンが配信され続ける問題への対応

Related: vektor-inc/multi-repo-tasks#7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * バージョン 0.1.7 が安定版として指定されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->