### PR TITLE
[ 7.0 対応 ] 非同期パターン挿入時にブロックを編集可能にする

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -32,7 +32,7 @@ e.g.
 
 == Changelog ==
 
-[ Other ][ Simple Copy Block ] Make blocks editable when inserted from patterns in WordPress 7.0.
+[ Other ][ Simple Copy Block ] Make blocks editable when inserted from an unsynced pattern in WordPress 7.0.
 
 = 0.1.7 =
 [ Specification change ] Disabled delete and move buttons for child blocks to prevent users from accidentally operating them.

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ e.g.
 
 == Changelog ==
 
+[ Other ][ Simple Copy Block ] Make blocks editable when inserted from patterns in WordPress 7.0.
+
 = 0.1.7 =
 [ Specification change ] Disabled delete and move buttons for child blocks to prevent users from accidentally operating them.
 

--- a/src/copy-button-wrap/block.json
+++ b/src/copy-button-wrap/block.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"className": true,
 		"spacing": {

--- a/src/copy-button/block.json
+++ b/src/copy-button/block.json
@@ -21,6 +21,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"className": true,
 		"color": {
 			"__experimentalSkipSerialization": true,

--- a/src/copy-target/block.json
+++ b/src/copy-target/block.json
@@ -7,6 +7,7 @@
 	"textdomain": "vk-simple-copy-block",
 	"parent": ["vk-simple-copy-block/simple-copy"],
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"className": true,
 		"spacing": {

--- a/src/simple-copy/block.json
+++ b/src/simple-copy/block.json
@@ -11,6 +11,7 @@
 		}
 	},
 	"supports": {
+		"contentRole": true,
 		"html": false,
 		"align": ["wide", "full"],
 		"className": true,


### PR DESCRIPTION
## 概要

WordPress 7.0 で非同期パターン（unsynced pattern）に含めて挿入したシンプルコピーブロック関連のブロックが、contentOnly モードによって編集不可（disabled）になる問題に対処します。

各ブロックの `block.json` の `supports` に `contentRole: true` を追加し、非同期パターン挿入時にも内部ブロックが contentOnly モードの編集対象として扱われるようにしました。

## 対象ブロック

- `vk-simple-copy-block/copy-button`
- `vk-simple-copy-block/simple-copy`
- `vk-simple-copy-block/copy-button-wrap`
- `vk-simple-copy-block/copy-target`

## 関連Issue

関連Issue: vektor-inc/multi-repo-tasks#10

## 既存ユーザーへの影響

- `supports` 拡張のみで `save` 出力（HTML マークアップ）は変わりません。既存投稿の再生成・再保存は不要です。
- WordPress 6.x 系では `contentRole` は未知の supports として無視されるため、挙動・互換性に影響はありません。
- WordPress 7.0 環境で非同期パターンから挿入した際の編集可否のみが変わります（編集できなかったものが編集できるようになる方向）。

## 確認手順

### 前提条件

- WordPress 7.0（RC2 以降）が動作するローカル環境
- 本プラグイン（vk-simple-copy-block）を有効化
- シンプルコピーブロック（およびその子ブロック）を含む非同期パターン（unsynced pattern）を 1 つ用意

### Before（修正前 / main 相当の挙動）

1. 投稿編集画面で、シンプルコピーブロックを含む非同期パターンを挿入する
2. 挿入された中の各ブロック（copy-button / copy-target / simple-copy / copy-button-wrap）をクリックして選択しようとする
   → 内部ブロックが disabled 表示になり、編集できない

### After（本 PR の挙動）

1. 投稿編集画面で、シンプルコピーブロックを含む非同期パターンを挿入する
2. 挿入された中の各ブロックをクリックして選択する
   → 内部ブロックが選択でき、テキスト編集や設定変更ができる
3. 非同期パターン外から（インサーターから直接）シンプルコピーブロックを挿入する
   → 従来通りの動作で問題なし（デグレなし）
4. WordPress 6.9 環境でも本プラグインを有効化して挿入する
   → 従来通りの動作で問題なし（`contentRole` が未知の supports として無視される）

## スクリーンショット

純粋に `supports` 拡張のため見た目の変化はありませんが、編集可否の差は WP 7.0 環境でのみ発生します。動作確認は上記手順で実施してください。

## 実装者チェックリスト

- [x] 変更ファイルの内容を目視で確認した（`git diff origin/main...HEAD` で確認済み）
- [x] readme.txt の Changelog に変更内容を追記した（英語・既存エントリの言語に合わせて）
- [x] 既存のテストが通ることを確認した（push 後の CI で確認）
- [x] 既存ユーザーへの影響を本文に明記した

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * WordPress 7.0 のパターンから挿入したブロックを編集可能にしました。
  * コピーボタン、コピー対象、シンプルコピーなど複数のブロックで contentRole サポートを有効化し、ブロック編集の柔軟性と互換性を向上しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vektor-inc/vk-simple-copy-block/pull/52?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->