### PR TITLE
[ 仕様変更 ] コピー処理を新しいブラウザ標準の方式に変更

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
 	extends: ['plugin:@wordpress/eslint-plugin/recommended'],
+	env: {
+		browser: true,
+	},
 	rules: {
 		'import/no-unresolved': 'off',
 		'import/no-extraneous-dependencies': 'off',

--- a/readme.txt
+++ b/readme.txt
@@ -32,6 +32,8 @@ e.g.
 
 == Changelog ==
 
+[ Spec Change ] Improved the copy button to use the modern browser standard method for copying to the clipboard.
+
 = 0.1.8 =
 [ Other ][ Simple Copy Block ] Make blocks editable when inserted from an unsynced pattern in WordPress 7.0.
 

--- a/src/simple-copy/view.js
+++ b/src/simple-copy/view.js
@@ -79,6 +79,10 @@ window.addEventListener('load', function () {
 			timeoutId[idx] = setTimeout(() => {
 				button.classList.remove('copy-success');
 			}, 3000);
+		} else {
+			// Log the failure when both the Clipboard API and execCommand fail. Clipboard API と execCommand の両方が失敗した場合にログを出力する
+			// eslint-disable-next-line no-console
+			console.error('vk-simple-copy-block: Failed to copy to clipboard');
 		}
 	}
 

--- a/src/simple-copy/view.js
+++ b/src/simple-copy/view.js
@@ -34,17 +34,41 @@ window.addEventListener('load', function () {
 	const buttons = document.querySelectorAll('.vk-simple-copy-button');
 
 	const timeoutId = [];
-	function handleClick(event) {
+
+	// Main click handler (uses the Clipboard API first, falling back to execCommand). クリック時のメインハンドラ（Clipboard API 優先・execCommand フォールバック）
+	async function handleClick(event) {
 		const button = event.currentTarget;
 
-		// Grab the pattern markup from hidden input
+		// Grab the pattern markup from hidden input. 隠し input からパターンのマークアップを取得する
 		const blockDataInput = button.previousElementSibling;
 
-		const content = JSON.parse(decodeURIComponent(blockDataInput.value));
+		// If JSON.parse fails, log the error and stop processing. JSON.parse 失敗時はエラーを出力して処理を中断する
+		let content;
+		try {
+			content = JSON.parse(decodeURIComponent(blockDataInput.value));
+		} catch (e) {
+			// eslint-disable-next-line no-console
+			console.error(
+				'vk-simple-copy-block: Failed to parse block data',
+				e
+			);
+			return;
+		}
 
-		const success = copyToClipboard(content);
+		// Use the Clipboard API as the primary method when available, and fall back to execCommand if it fails. Clipboard API が利用可能な場合は主処理として使用し、失敗した場合は execCommand にフォールバックする
+		let success = false;
+		if (navigator.clipboard) {
+			try {
+				await navigator.clipboard.writeText(content);
+				success = true;
+			} catch (e) {
+				success = copyToClipboard(content);
+			}
+		} else {
+			success = copyToClipboard(content);
+		}
 
-		// Make sure we reset focus in case it was lost in the 'copy' command.
+		// Make sure we reset focus in case it was lost in the 'copy' command. 'copy' コマンド実行中にフォーカスが失われた場合に備えてフォーカスを戻す
 		button.focus();
 
 		if (success) {
@@ -55,8 +79,6 @@ window.addEventListener('load', function () {
 			timeoutId[idx] = setTimeout(() => {
 				button.classList.remove('copy-success');
 			}, 3000);
-		} else {
-			// TODO Handle error case
 		}
 	}
 


### PR DESCRIPTION
## 概要

コピーボタンのクリック処理で使用していた `document.execCommand('copy')`（旧来のコピー命令）は非推奨（deprecated）となっており、将来のブラウザで動作しなくなる可能性があります。本PRでは、`navigator.clipboard.writeText()`（Clipboard API＝新しいブラウザ標準のクリップボード機能）を主処理に変更し、旧方式はフォールバック（代替手段）として残します。

関連Issue: #53

## 変更内容

- `src/simple-copy/view.js`
  - クリック処理を Clipboard API 優先に変更。API が使えない環境（HTTP接続など）や書き込みが拒否された場合は、従来の `execCommand` 方式に自動で切り替え
  - `JSON.parse()`（コピー対象データの読み取り処理）に try-catch（エラーを捕まえて安全に中断する仕組み）を追加。データが壊れていた場合はコンソールにエラーを出力して処理を中断
- `.eslintrc.js`
  - `env: { browser: true }` を追加（`navigator` などブラウザ標準のグローバル変数を lint が未定義と誤判定しないようにするための設定）
- `readme.txt`
  - changelog に追記

## 既存ユーザーへの影響

- ブロックの保存内容（HTML出力）には変更がありません（`save.js` は未変更）。既存ページに設置済みのコピーボタンも、再保存なしでそのまま新しい処理で動作します。
- HTTPS で表示しているサイトは Clipboard API、HTTP のサイトは従来方式が自動で使われるため、どちらの環境でも従来どおりコピーできます。

## テスト（確認手順）

前提: 本PRのブランチをチェックアウトし、`npm ci && npm run build` を実行しておく。

### コピー動作の確認（Clipboard API 経路）

1. 管理画面で新規固定ページを作成し、ブロック挿入から「Simple Copy」ブロックを追加する
2. ブロック内のコピー対象（Copy Target）に段落ブロックなど適当なコンテンツを入れ、ページを公開する
3. 公開したページをフロントで表示し、コピーボタンをクリックする
   → ボタンが「コピーしました」の成功表示（チェックアイコン）に切り替わり、約3秒で元に戻る
4. 新規投稿のブロックエディタを開き、本文に貼り付け（Cmd+V / Ctrl+V）する
   → コピー対象に入れたブロックがそのまま挿入される

### フォールバック（従来方式）の確認

5. 同じページを HTTP（`http://` 始まりのURL）で表示してコピーボタンをクリックする
   → HTTP では Clipboard API が無効になるため従来方式が使われるが、手順3〜4と同じ結果になる
   ※ ローカル環境が HTTPS のみの場合は、ブラウザの開発者ツールのコンソールで `delete Navigator.prototype.clipboard` を実行してから再度ボタンをクリックすることでも代替確認が可能

### デグレ確認

6. 本PR適用前に作成した固定ページ（既存コンテンツ）のコピーボタンでも手順3〜4を行う
   → 再保存していない既存ページでも同様にコピーできる

## スクリーンショット

表示・UIの変更はないため省略します（ロジックのみの変更）。

## テストコードについて

変更は JS のフロント処理のみ（PHP の変更なし）のため、PHPUnit テストの追加はありません。ブラウザ実機での動作確認は上記手順および e2e テスト担当のレビューで実施します。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * コピー機能が、モダンなブラウザ標準のクリップボード書き込み方法を優先して利用するよう改善されました。
  * 失敗時や非対応環境では、従来方式へ自動でフォールバックします。
* **バグ修正**
  * コピー対象の解析に失敗した場合でも例外処理で中断し、エラーを記録するようにしました。
* **ドキュメント**
  * 変更履歴（Changelog）にコピー方法の改善内容を追記しました。
* **チョア**
  * ブラウザ環境前提をESLint設定で明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->