### PR TITLE
[ 不具合修正 ][ Simple Copy Block ] コピー対象データが見つからない場合にブロック出力が空になる不具合を修正

### DIFF
--- a/inc/blocks.php
+++ b/inc/blocks.php
@@ -95,6 +95,12 @@ function vk_simple_copy_block_render( $block_content, $block ) {
 		$block_content     = str_replace( '<input type="hidden"/>', '<input type="hidden" value="' . rawurlencode( wp_json_encode( $raw_block_content ) ) . '" />', $block_content );
 		return $block_content;
 	}
+
+	// $array に対象の blockId が存在しない場合も、加工前の $block_content をそのまま返す。
+	// これを忘れると null が返り、フィルタ経由でブロックの出力自体が空になってしまう。
+	// Also return the original $block_content when the target blockId does not exist in $array.
+	// Without this, the function returns null, which would empty out the block output via the filter.
+	return $block_content;
 }
 add_filter( 'render_block_vk-simple-copy-block/simple-copy', 'vk_simple_copy_block_render', 10, 2 );
 

--- a/readme.txt
+++ b/readme.txt
@@ -33,9 +33,7 @@ e.g.
 == Changelog ==
 
 [ Spec Change ] Improved the copy button to use the modern browser standard method for copying to the clipboard.
-
 [ Bug Fix ][ Simple Copy Block ] Fixed a possible PHP 8 "Undefined array key" warning when rendering blocks that have no blockId attribute.
-
 [ Bug Fix ][ Simple Copy Block ] Fixed the block output becoming empty (null) when the target blockId has no matching copy content.
 
 = 0.1.8 =

--- a/readme.txt
+++ b/readme.txt
@@ -36,6 +36,8 @@ e.g.
 
 [ Bug Fix ][ Simple Copy Block ] Fixed a possible PHP 8 "Undefined array key" warning when rendering blocks that have no blockId attribute.
 
+[ Bug Fix ][ Simple Copy Block ] Fixed the block output becoming empty (null) when the target blockId has no matching copy content.
+
 = 0.1.8 =
 [ Other ][ Simple Copy Block ] Make blocks editable when inserted from an unsynced pattern in WordPress 7.0.
 

--- a/test/phpunit/test-vk-simple-copy.php
+++ b/test/phpunit/test-vk-simple-copy.php
@@ -111,8 +111,23 @@ class SimpleCopyTest extends WP_UnitTestCase {
 	 * PHP 8 の "Undefined array key" 警告を出さずに $block_content をそのまま返すことを検証する。
 	 * Verify that a block without a valid blockId returns the original $block_content
 	 * without emitting a PHP 8 "Undefined array key" warning.
+	 *
+	 * また、$array（コピー対象コンテンツの配列）自体は空でないが、
+	 * 対象の blockId が $array に存在しないケースでも $block_content をそのまま返すこと
+	 * （null を返さないこと）を検証する。（Issue #55）
+	 * Also verifies that when $array (the array of copy target contents) itself is not empty,
+	 * but the target blockId does not exist in $array, the function still returns $block_content
+	 * as-is (and not null). (Issue #55)
 	 */
 	public function test_vk_simple_copy_block_render() {
+
+		// setUp() で作成した投稿へ遷移し、get_the_content() が実データを返す状態にする。
+		// これにより vk_simple_copy_block_get_copy_target_block_contents() が返す $array が
+		// 空でない状態でテストできる（Issue #55 の再現に必要）。
+		// Go to the post created in setUp() so that get_the_content() returns real data.
+		// This lets vk_simple_copy_block_get_copy_target_block_contents() return a non-empty
+		// $array while under test (required to reproduce the bug in Issue #55).
+		$this->go_to( get_permalink( $this->post_id ) );
 
 		// テスト用のダミーブロックコンテンツ。
 		// Dummy block content used for every case.


### PR DESCRIPTION
## 概要

close #55

`vk_simple_copy_block_render()`（`inc/blocks.php`）は、コピー対象データが `$block_id` に対して見つからない場合に return 文が無く、暗黙的に `null` を返していました。この関数は `render_block_vk-simple-copy-block/simple-copy` フィルタに登録されているため、null が返るとブロックの出力自体が空になってしまう不具合がありました。

関数末尾に `return $block_content;` を追加し、対象データが見つからない場合も加工前の `$block_content` をそのまま返すように修正しました。

## テスト（確認手順）

### Before（修正前の再現手順）

1. 修正前のコード（`fix/issue-55-null-return` の1つ前のコミット）で `test/phpunit/test-vk-simple-copy.php` の `test_vk_simple_copy_block_render` を実行する
   → `blockId は設定されているがコピー対象コンテンツが無い場合` のケースで `null` が返り、テストが失敗する（`Failed asserting that null is identical to '<div>dummy</div>'.`）

### After（修正後の確認手順）

1. このブランチの `inc/blocks.php` の修正を適用した状態で、同じテストを実行する
   → `$block_content`（加工前の元の内容）がそのまま返り、テストが成功する
2. `npm run phpunit`（または wp-env 経由）でテストスイート全体を実行する
   → 全テスト成功（`OK (3 tests, 24 assertions)`）

## 備考

- 表示・UI に影響する変更はないため、スクリーンショットは省略します。
- changelog（`readme.txt`）に追記済みです。

---

🤖 このタスクは task-queue 経由の自動オーケストレーターにより処理されています。メタ issue: https://github.com/vektor-inc/task-queue/issues/238

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 対象ブロックが `blockId` を持たない場合でも、PHP 8 の「Undefined array key」警告が出ないよう修正しました。
  * 指定 `blockId` に一致するコピー内容がない場合でも、ブロック出力が空にならず元の表示を維持するよう修正しました。  
* **Tests**
  * 状態を整えたうえで、出力が維持されること・`null` にならないことを確認するテストを強化しました。  
* **Documentation**
  * 不具合修正内容を Changelog に追記しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->